### PR TITLE
descriptor notifications now move waiters into the io thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See the [Keep a Changelog formatting convention](https://keepachangelog.com/en/1
 
 ## Unreleased
 
-## v0.0.0.2 2021/10/11
+## v0.0.0.2 2021/12/22
 
 ### Added
 
@@ -18,7 +18,7 @@ See the [Keep a Changelog formatting convention](https://keepachangelog.com/en/1
 - Made a simpler echo server and moved current one to `logging_echo_server.cpp`
 - epoll no longer handles any timeouts. All timers are now performed by `timing_service`.
 - order_t is now relative (in nano-seconds) and no longer supports negative ordering.
-
+- descriptor notifications now move waiters into the io thread for their operations.
 ### Fixed
 - Bug with event loop not picking the least busy loop in `kAnyThread`.
 

--- a/example/echo_server.cpp
+++ b/example/echo_server.cpp
@@ -108,7 +108,7 @@ namespace zab_example {
 
                 while (!_stream.last_error())
                 {
-                    auto data = co_await _stream.read();
+                    auto data = co_await _stream.read_some(1028 * 1028);
 
                     if (data) { co_await _stream.write(*data); }
                     else

--- a/example/echo_server.cpp
+++ b/example/echo_server.cpp
@@ -47,6 +47,7 @@
 #include "zab/engine_enabled.hpp"
 #include "zab/event_loop.hpp"
 #include "zab/file_io_overlay.hpp"
+#include "zab/for_each.hpp"
 #include "zab/network_overlay.hpp"
 #include "zab/strong_types.hpp"
 #include "zab/tcp_stream.hpp"
@@ -109,18 +110,7 @@ namespace zab_example {
                 {
                     auto data = co_await _stream.read();
 
-                    if (data)
-                    {
-                        /* echo the data back */
-                        size_t data_to_write = 0;
-                        while (data_to_write != data->size() && !_stream.last_error())
-                        {
-                            /* Write may return less then we wanted to */
-                            data_to_write = co_await _stream.write(std::span<const char>(
-                                data->data() + data_to_write,
-                                data->size() - data_to_write));
-                        }
-                    }
+                    if (data) { co_await _stream.write(*data); }
                     else
                     {
 

--- a/example/logging_echo_server.cpp
+++ b/example/logging_echo_server.cpp
@@ -153,7 +153,7 @@ namespace zab_example {
 
                 while (!_stream.last_error())
                 {
-                    auto data = co_await _stream.read();
+                    auto data = co_await _stream.read_some(1028 * 1028);
 
                     if (data)
                     {

--- a/example/logging_echo_server.cpp
+++ b/example/logging_echo_server.cpp
@@ -47,10 +47,10 @@
 #include "zab/engine_enabled.hpp"
 #include "zab/event_loop.hpp"
 #include "zab/file_io_overlay.hpp"
+#include "zab/for_each.hpp"
 #include "zab/network_overlay.hpp"
 #include "zab/strong_types.hpp"
 #include "zab/tcp_stream.hpp"
-
 namespace zab_example {
 
     class echo_server : public zab::engine_enabled<echo_server> {
@@ -91,7 +91,7 @@ namespace zab_example {
 
                     for (const auto i : active_streams_)
                     {
-                        i->cancel_read();
+                        i->cancel();
                     }
                 }
 
@@ -161,14 +161,7 @@ namespace zab_example {
                         print(thread, _connection_count, "Read ", data->size(), " bytes.");
 
                         /* echo the data back */
-                        size_t data_to_write = 0;
-                        while (data_to_write != data->size() && !_stream.last_error())
-                        {
-                            /* Write may return less then we wanted to */
-                            data_to_write = co_await _stream.write(std::span<const char>(
-                                data->data() + data_to_write,
-                                data->size() - data_to_write));
-                        }
+                        co_await _stream.write(*data);
 
                         /* log data to file */
                         auto s = co_await log_file.write_to_file(*data);

--- a/includes/zab/descriptor_notifications.hpp
+++ b/includes/zab/descriptor_notifications.hpp
@@ -93,10 +93,10 @@ namespace zab {
              */
             enum NoticationType {
                 kError     = EPOLLERR,
-                kRead      = EPOLLIN,
-                kWrite     = EPOLLOUT,
+                kRead      = EPOLLIN | EPOLLRDNORM,
+                kWrite     = EPOLLOUT | EPOLLWRNORM,
                 kException = EPOLLPRI,
-                kClosed    = EPOLLRDHUP
+                kClosed    = EPOLLRDHUP | EPOLLHUP
             };
 
             /**
@@ -281,10 +281,11 @@ namespace zab {
                      */
                     descriptor(const descriptor&) = delete;
 
-                    std::unique_ptr<descriptor_op>
+                    void
                     add_operation(
-                        descriptor_op::type     _type,
-                        std::coroutine_handle<> _handle) noexcept;
+                        descriptor_op::type             _type,
+                        std::coroutine_handle<>         _handle,
+                        std::unique_ptr<descriptor_op>& _op) noexcept;
 
                     bool
                     re_arm(descriptor_op::type _type) noexcept;

--- a/includes/zab/descriptor_notifications.hpp
+++ b/includes/zab/descriptor_notifications.hpp
@@ -234,7 +234,7 @@ namespace zab {
                     inline void
                     cancel()
                     {
-                        desc_->cancel();
+                        if (desc_) { desc_->cancel(); }
                     }
 
                 private:

--- a/includes/zab/engine_enabled.hpp
+++ b/includes/zab/engine_enabled.hpp
@@ -319,7 +319,6 @@ namespace zab {
             [[nodiscard]] inline auto
             yield(order_t _order = now(), thread_t _thread = default_thread()) const noexcept
             {
-                // std::cout << "thread is: " << _thread << "\n";
                 return zab::yield(get_engine(), _order, _thread);
             }
 

--- a/includes/zab/first_of.hpp
+++ b/includes/zab/first_of.hpp
@@ -81,6 +81,25 @@ namespace zab {
                 _function,
                 std::make_index_sequence<sizeof...(Results)>{});
         }
+
+        struct unwinder {
+
+                unwinder(std::shared_ptr<std::atomic<zab::pause_pack*>> _data)
+                    : data_(std::move(_data))
+                { }
+
+                ~unwinder()
+                {
+                    if (data_)
+                    {
+                        auto handle = data_->exchange(nullptr, std::memory_order_acquire);
+                        if (handle) { handle->handle_.destroy(); }
+                    }
+                }
+
+                std::shared_ptr<std::atomic<zab::pause_pack*>> data_;
+        };
+
     }   // namespace details
 
     template <typename T>
@@ -122,11 +141,16 @@ namespace zab {
                             [](auto _handle, auto& _result, auto _future, auto _engine) noexcept
                                 -> async_function<>
                             {
+                                /* This is here to ensure cleanup in case of coroutine unwinding */
+                                details::unwinder clean_up(_handle);
+
                                 if constexpr (std::is_same_v<
                                                   void,
                                                   std::decay_t<decltype(co_await _future)>>)
                                 {
                                     co_await _future;
+
+                                    clean_up.data_ = nullptr;
 
                                     auto handle =
                                         _handle->exchange(nullptr, std::memory_order_acquire);
@@ -138,8 +162,9 @@ namespace zab {
                                 }
                                 else
                                 {
-
                                     auto res = co_await _future;
+
+                                    clean_up.data_ = nullptr;
 
                                     auto handle =
                                         _handle->exchange(nullptr, std::memory_order_acquire);

--- a/includes/zab/timer_service.hpp
+++ b/includes/zab/timer_service.hpp
@@ -119,7 +119,9 @@ namespace zab {
 
             engine* engine_;
 
-            descriptor_notification::descriptor_waiter waiter_;
+            int timer_fd_;
+
+            std::optional<descriptor_notification::notifier> waiter_;
 
             std::uint64_t current_;
 

--- a/src/descriptor_notifications.cpp
+++ b/src/descriptor_notifications.cpp
@@ -198,13 +198,17 @@ namespace zab {
 
     descriptor_notification::descriptor::~descriptor()
     {
-        for (auto tmp = ops_head_; tmp;)
+        auto tmp  = ops_head_;
+        ops_head_ = nullptr;
+        ops_tail_ = nullptr;
+
+        while (tmp)
         {
             tmp->desc_ = nullptr;
 
             if (tmp->handle_)
             {
-                tmp->flags_ = descriptor_notification::kError | descriptor_notification::kException;
+                tmp->flags_ = 0;
 
                 auto to_resume = tmp->handle_;
                 tmp->handle_   = nullptr;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -61,8 +61,10 @@ namespace zab {
 
     engine::~engine()
     {
-        /* Destroy the timer first so it can clean up. */
         timer_ = nullptr;
+
+        event_loop_.purge();
+        notifcations_.purge();
         event_loop_.purge();
     }
 
@@ -76,9 +78,13 @@ namespace zab {
     engine::resume(event _handle, order_t _order, thread_t _thread) noexcept
     {
         if (!_order.order_) { event_loop_.send_event(_handle, _thread); }
-        else
+        else if (timer_)
         {
             timer_->wait(_handle, _order.order_, _thread);
+        }
+        else
+        {
+            _handle.destroy();
         }
     }
 

--- a/src/network_overlay.cpp
+++ b/src/network_overlay.cpp
@@ -412,7 +412,8 @@ namespace zab {
                 else
                 {
                     char ch;
-                    ::read(waiter_->file_descriptor(), &ch, 0);
+                    auto rc = ::read(waiter_->file_descriptor(), &ch, 0);
+                    (void) rc;
                     last_error_ = errno;
 
                     if (!last_error_) { last_error_ = EWOULDBLOCK; }

--- a/src/network_overlay.cpp
+++ b/src/network_overlay.cpp
@@ -59,8 +59,7 @@ namespace zab {
             if (::close(_socket) && errno != EBADF)
             {
 
-                std::cerr << "zab: A network overlay socket failed to close. "
-                          << "\n";
+                std::cerr << "zab: A network overlay socket failed to close.\n";
             }
         }
     }   // namespace
@@ -190,19 +189,21 @@ namespace zab {
             return false;
         }
 
-        waiter_->set_flags(
-            descriptor_notification::kError | descriptor_notification::kException |
-            descriptor_notification::kRead);
-
         return true;
     }
 
     simple_future<tcp_stream>
-    tcp_acceptor::accept(int _timeout) noexcept
+    tcp_acceptor::accept() noexcept
     {
+        bool     swapped_threads = false;
+        thread_t rejoin_thread{engine_->get_event_loop().current_id()};
+
         struct sockaddr_storage address;
         socklen_t               addlen = sizeof(address);
         ::memset(&address, 0, sizeof(address));
+
+        std::unique_ptr<descriptor_notification::descriptor_op> read_op;
+        std::optional<tcp_stream>                               stream;
         while (true)
         {
             if (int sd = ::accept4(
@@ -212,57 +213,120 @@ namespace zab {
                     SOCK_NONBLOCK | SOCK_CLOEXEC);
                 sd >= 0)
             {
-                tcp_stream stream(get_engine(), sd);
+                stream.emplace(get_engine(), sd);
 
-                if (!stream.last_error()) { co_return stream; }
-                else
+                if (stream->last_error())
                 {
-
-                    last_error_ = stream.last_error();
-                    co_return std::nullopt;
+                    stream      = std::nullopt;
+                    last_error_ = stream->last_error();
                 }
+
+                break;
             }
             else if (errno == EAGAIN || errno == EWOULDBLOCK)
             {
-                /* We do not care if its an error */
-                /* Next call to accept will reveal! */
                 std::uint32_t flags = 0;
 
-                if (_timeout < 1) { flags = co_await *waiter_; }
-                else
+                if (!swapped_threads)
                 {
-                    auto result = co_await first_of(
-                        engine_,
-                        AwaitWrapper(*waiter_),
-                        engine_->get_timer().wait_proxy(_timeout));
+                    read_op = co_await join_io_thread();
 
-                    auto index = result.index();
-
-                    if (index == 0) { flags = std::get<int>(result); }
-
-                    if (!flags)
+                    if (read_op)
                     {
-                        /* must of timed out...*/
-                        last_error_ = 0;
-                        co_return std::nullopt;
+                        swapped_threads = true;
+                        flags           = read_op->flags();
+                    }
+                    else
+                    {
+                        break;
                     }
                 }
+                else
+                {
+                    if (!read_op)
+                    {
+                        last_error_ = errno;
+                        break;
+                    }
+
+                    flags = co_await *read_op;
+                }
+
+                /* No flags means something happened internally */
+                /* Like a cancel or deconstruction              */
+                if (!flags) { break; }
             }
             else
             {
 
                 last_error_ = errno;
-                co_return std::nullopt;
+                break;
             }
         }
+
+        if (swapped_threads) { co_await yield(rejoin_thread); }
+
+        co_return stream;
+    }
+
+    [[nodiscard]] guaranteed_future<std::unique_ptr<descriptor_notification::descriptor_op>>
+    tcp_acceptor::join_io_thread() noexcept
+    {
+        return waiter_->start_read_operation();
+    }
+
+    simple_future<tcp_stream>
+    tcp_acceptor::accept_io(descriptor_notification::descriptor_op& _op) noexcept
+    {
+        struct sockaddr_storage address;
+        socklen_t               addlen = sizeof(address);
+        ::memset(&address, 0, sizeof(address));
+
+        std::optional<tcp_stream> stream;
+        while (true)
+        {
+            if (int sd = ::accept4(
+                    waiter_->file_descriptor(),
+                    (struct sockaddr*) &address,
+                    &addlen,
+                    SOCK_NONBLOCK | SOCK_CLOEXEC);
+                sd >= 0)
+            {
+                stream.emplace(get_engine(), sd);
+
+                if (stream->last_error())
+                {
+                    stream      = std::nullopt;
+                    last_error_ = stream->last_error();
+                }
+
+                break;
+            }
+            else if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+                co_await _op;
+            }
+            else
+            {
+                last_error_ = errno;
+                break;
+            }
+        }
+
+        co_return stream;
     }
 
     simple_future<tcp_stream>
     tcp_connector::connect(
         struct sockaddr_storage* _details,
         socklen_t                _size,
-        int                      _timeout) noexcept
+        bool                     _return_thread) noexcept
     {
+        bool     swapped_threads = false;
+        thread_t rejoin_thread{engine_->get_event_loop().current_id()};
+
+        std::optional<tcp_stream> stream;
+
         if (!waiter_)
         {
             int socket;
@@ -286,57 +350,29 @@ namespace zab {
         if (::connect(waiter_->file_descriptor(), (const sockaddr*) _details, _size) == 0 ||
             errno == EISCONN)
         {
-            co_return tcp_stream(get_engine(), std::move(waiter_));
-        }
-        else if (
-            errno == EINPROGRESS || errno == EAGAIN || errno == EWOULDBLOCK || errno == EALREADY)
-        {
-            /* We have EALREADY in case they call connect again after a time out... */
-            /* In that case, we wait for writabilty or an error. */
-            // waiter_->set_timeout(_timeout);
+            stream.emplace(get_engine(), std::move(waiter_));
 
-            waiter_->set_flags(
-                descriptor_notification::kClosed | descriptor_notification::kException |
-                descriptor_notification::kError | descriptor_notification::kWrite);
+            waiter_ = std::nullopt;
+        }
+        else if (errno == EINPROGRESS || errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            swapped_threads = true;
 
             /* We do not care if its an error */
             /* Next call to accept will reveal! */
-            std::uint32_t flags = 0;
+            auto write_op = co_await waiter_->start_write_operation();
 
-            if (_timeout < 1) { flags = co_await *waiter_; }
-            else
-            {
-                auto result = co_await first_of(
-                    engine_,
-                    AwaitWrapper(*waiter_),
-                    engine_->get_timer().wait_proxy(_timeout));
-
-                auto index = result.index();
-
-                if (index == 0) { flags = std::get<int>(result); }
-
-                if (!flags)
-                {
-                    /* must of timed out...*/
-                    last_error_ = 0;
-                    co_return std::nullopt;
-                }
-            }
-
-            if (flags & descriptor_notification::kWrite)
+            if (write_op && write_op->flags() & descriptor_notification::kWrite)
             {
                 /* I think its odd that a failed connect socket can be writable... */
                 /* but we will handle this case anyways...                         */
                 struct sockaddr addr;
                 socklen_t       addrlen = sizeof(addr);
                 auto            rc = ::getpeername(waiter_->file_descriptor(), &addr, &addrlen);
-
                 if (!rc)
                 {
-                    auto tmp = tcp_stream(get_engine(), std::move(waiter_));
+                    stream.emplace(get_engine(), std::move(waiter_));
                     waiter_.reset();
-
-                    co_return tmp;
                 }
                 else
                 {
@@ -353,14 +389,16 @@ namespace zab {
                 auto rc = ::read(waiter_->file_descriptor(), &ch, 1);
                 (void) rc;
                 last_error_ = errno;
-                co_return std::nullopt;
             }
         }
         else
         {
             last_error_ = errno;
-            co_return std::nullopt;
         }
+
+        if (_return_thread && swapped_threads) { co_await yield(rejoin_thread); }
+
+        co_return stream;
     }
 
 }   // namespace zab

--- a/src/network_overlay.cpp
+++ b/src/network_overlay.cpp
@@ -258,7 +258,6 @@ namespace zab {
             }
             else
             {
-
                 last_error_ = errno;
                 break;
             }

--- a/src/tcp_stream.cpp
+++ b/src/tcp_stream.cpp
@@ -353,7 +353,9 @@ namespace zab {
 
     void
     tcp_stream::cancel() noexcept
-    { }
+    {
+        if (state_) { state_->socket_->cancel(); }
+    }
 
     simple_future<>
     tcp_stream::clean_up(engine* _engine, std::unique_ptr<internal_state>&& _state) noexcept

--- a/src/tcp_stream.cpp
+++ b/src/tcp_stream.cpp
@@ -54,55 +54,39 @@
 #include <unistd.h>
 
 #include "zab/first_of.hpp"
+#include "zab/for_each.hpp"
 #include "zab/strong_types.hpp"
 #include "zab/timer_service.hpp"
 
 namespace zab {
 
     tcp_stream::internal_state::internal_state(
-        engine*                                                     _engine,
-        std::optional<descriptor_notification::descriptor_waiter>&& _desc)
-        : mtx_(_engine), socket_(std::move(_desc)), last_error_(0)
+        std::optional<descriptor_notification::notifier>&& _desc)
+        : socket_(std::move(_desc)), last_error_(0)
     { }
 
+    tcp_stream::internal_state::~internal_state() { }
+
     tcp_stream::tcp_stream(engine* _engine, int _fd)
-        : state_(std::make_unique<internal_state>(
-              _engine,
-              _engine->get_notification_handler().subscribe(_fd)))
+        : state_(
+              std::make_unique<internal_state>(_engine->get_notification_handler().subscribe(_fd)))
     {
         register_engine(*_engine);
-        if (state_->socket_) { set_flags(); }
-        else
-        {
-
-            state_->last_error_ = errno;
-        }
+        if (!state_->socket_) { state_->last_error_ = errno; }
     }
 
     tcp_stream::tcp_stream(
-        engine*                                                     _engine,
-        std::optional<descriptor_notification::descriptor_waiter>&& _awaiter)
-        : state_(std::make_unique<internal_state>(_engine, std::move(_awaiter)))
+        engine*                                            _engine,
+        std::optional<descriptor_notification::notifier>&& _awaiter)
+        : state_(std::make_unique<internal_state>(std::move(_awaiter)))
     {
         register_engine(*_engine);
-        if (state_->socket_) { set_flags(); }
-        else
-        {
-            _engine = nullptr;
-        }
+        if (!state_->socket_) { _engine = nullptr; }
     }
 
     tcp_stream::tcp_stream(tcp_stream&& _move) : state_(std::move(_move.state_))
     {
         register_engine(*_move.engine_);
-    }
-
-    void
-    tcp_stream::set_flags() noexcept
-    {
-        state_->socket_->set_flags(
-            descriptor_notification::kClosed | descriptor_notification::kException |
-            descriptor_notification::kError | descriptor_notification::kRead);
     }
 
     tcp_stream&
@@ -117,187 +101,246 @@ namespace zab {
 
     tcp_stream::~tcp_stream()
     {
-        if (state_)
-        {
-            cancel_read();
-            clean_up_and_forget(get_engine(), std::move(state_));
-        }
+        if (state_) { clean_up_and_forget(get_engine(), std::move(state_)); }
     }
 
     simple_future<>
     tcp_stream::shutdown() noexcept
     {
-        cancel_read();
-        co_await clean_up(get_engine(), state_);
-        state_ = nullptr;
+        co_await clean_up(get_engine(), std::move(state_));
     }
 
     simple_future<std::vector<char>>
-    tcp_stream::read(size_t _amount, int64_t _timeout) noexcept
+    tcp_stream::read(size_t _amount, descriptor_notification::descriptor_op* _op) noexcept
     {
-        thread_t rejoin_thread{engine_->get_event_loop().current_id()};
-        // state_->socket_->set_timeout(_timout);
+        std::vector<char> buffer(_amount);
 
-        std::vector<char> buffer;
-        buffer.reserve(_amount);
+        auto amount = co_await read(buffer, _op);
 
-        while ((_amount && buffer.size() != _amount) || (!_amount && !buffer.size()))
-        {
-            auto to_ask = std::min(_amount - buffer.size(), kBufferSize);
-            if (to_ask == 0) { to_ask = kBufferSize; }
-            size_t old_size = buffer.size();
-            buffer.resize(old_size + to_ask);
-
-            if (int64_t numbytes =
-                    ::recv(state_->socket_->file_descriptor(), buffer.data() + old_size, to_ask, 0);
-                numbytes > 0)
-            {
-                buffer.resize(old_size + numbytes);
-                co_await yield(now(), rejoin_thread);
-            }
-            else if (numbytes == 0)
-            {
-                buffer.resize(old_size);
-
-                if (buffer.size()) { co_return buffer; }
-                else
-                {
-
-                    co_return std::nullopt;
-                }
-            }
-            else if (errno == EAGAIN || errno == EWOULDBLOCK)
-            {
-                buffer.resize(old_size);
-
-                std::uint32_t flags = 0;
-
-                auto finished = std::make_shared<bool>();
-
-                if (_timeout < 1)
-                {
-                    auto result = co_await first_of(
-                        engine_,
-                        pause(
-                            [this](auto _handle) noexcept
-                            {
-                                _handle->thread_ = engine_->get_event_loop().current_id();
-                                auto old_handle  = state_->cancel_handle_.exchange(
-                                    _handle,
-                                    std::memory_order_release);
-                                if (old_handle) { old_handle->handle_.destroy(); }
-                            }),
-                        AwaitWrapper(*state_->socket_));
-
-                    auto index = result.index();
-
-                    if (index == 1) { flags = std::get<int>(result); }
-                }
-                else
-                {
-                    auto result = co_await first_of(
-                        engine_,
-                        pause(
-                            [this](auto _handle) noexcept
-                            {
-                                _handle->thread_ = engine_->get_event_loop().current_id();
-                                auto old_handle  = state_->cancel_handle_.exchange(
-                                    _handle,
-                                    std::memory_order_release);
-                                if (old_handle) { old_handle->handle_.destroy(); }
-                            }),
-                        AwaitWrapper(*state_->socket_),
-                        engine_->get_timer().wait_proxy(_timeout));
-
-                    auto index = result.index();
-
-                    if (index == 1) { flags = std::get<int>(result); }
-                }
-
-                if (!flags)
-                {
-                    /* must of been cancelled...*/
-                    state_->last_error_ = 0;
-                    if (buffer.size()) { co_return buffer; }
-                    else
-                    {
-                        co_return std::nullopt;
-                    }
-                }
-            }
-            else
-            {
-                buffer.resize(old_size);
-                state_->last_error_ = errno;
-                if (buffer.size()) { co_return buffer; }
-                else
-                {
-                    co_return std::nullopt;
-                }
-            }
-        }
+        buffer.resize(amount);
 
         co_return buffer;
     }
 
-    guaranteed_future<size_t>
-    tcp_stream::write(std::span<const char> _data) noexcept
+    [[nodiscard]] guaranteed_future<std::size_t>
+    tcp_stream::read(std::span<char> _data, descriptor_notification::descriptor_op* _op) noexcept
     {
+        if (_op && _op->op_type() == descriptor_notification::descriptor_op::type::kWrite)
+            [[unlikely]]
+        {
+            state_->last_error_ = 0;
+            co_return 0;
+        }
+
+        bool     rejoin      = _op == nullptr;
+        bool     left_thread = false;
         thread_t rejoin_thread{engine_->get_event_loop().current_id()};
 
-        /* Do not worry about out of order writes... */
-        /* Mutex will resume in order of suspension  */
-        auto   lock     = co_await state_->mtx_;
-        size_t written  = 0;
-        auto   back_off = order::milli(1);
-        while (written < _data.size())
-        {
-            auto to_send = std::min(_data.size() - written, kBufferSize);
+        std::size_t so_far = 0;
+        const auto  sd     = state_->socket_->file_descriptor();
 
-            if (int64_t numbytes = ::send(
-                    state_->socket_->file_descriptor(),
-                    _data.data() + written,
-                    to_send,
-                    MSG_NOSIGNAL);
+        std::unique_ptr<descriptor_notification::descriptor_op> op;
+        do
+        {
+            if (int64_t numbytes = ::recv(sd, _data.data() + so_far, _data.size() - so_far, 0);
                 numbytes > 0)
             {
-                written += numbytes;
-                co_await yield(now(), rejoin_thread);
+                so_far += numbytes;
             }
-            else if (!numbytes || errno == EWOULDBLOCK || errno == EAGAIN)
+            else if (numbytes == 0 || errno == EAGAIN || errno == EWOULDBLOCK)
             {
-                co_await yield(now() + back_off, rejoin_thread);
+                std::uint32_t flags = 0;
 
-                if (back_off < order::seconds(1)) { back_off.order_ <<= 1; }
+                if (_op) { flags = co_await *_op; }
                 else
                 {
-                    state_->last_error_ = 0;
-                    break;
+                    left_thread = true;
+                    op          = co_await start_read_operation();
+
+                    if (!op)
+                    {
+                        state_->last_error_ = 0;
+                        break;
+                    }
+                    _op   = op.get();
+                    flags = op->flags();
                 }
+
+                /* No flags means something happened internally */
+                /* Like a cancel or deconstruction              */
+                if (!flags) { break; }
             }
             else
             {
                 state_->last_error_ = errno;
-
                 break;
             }
+
+        } while (so_far != _data.size());
+
+        if (rejoin && left_thread) { co_await yield(rejoin_thread); }
+
+        co_return so_far;
+    }
+
+    simple_future<std::vector<char>>
+    tcp_stream::read_some(size_t _max, descriptor_notification::descriptor_op* _op) noexcept
+    {
+        std::vector<char> data(_max);
+
+        if (auto size = co_await read_some(data, _op); size)
+        {
+            data.resize(size);
+            co_return data;
         }
+        else
+        {
+            co_return std::nullopt;
+        }
+    }
+
+    guaranteed_future<std::size_t>
+    tcp_stream::read_some(
+        std::span<char>                         _data,
+        descriptor_notification::descriptor_op* _op) noexcept
+    {
+        if (_op && _op->op_type() == descriptor_notification::descriptor_op::type::kWrite)
+            [[unlikely]]
+        {
+            state_->last_error_ = 0;
+            co_return 0;
+        }
+
+        bool     rejoin      = _op == nullptr;
+        bool     left_thread = false;
+        thread_t rejoin_thread{engine_->get_event_loop().current_id()};
+
+        std::size_t so_far = 0;
+        const auto  sd     = state_->socket_->file_descriptor();
+
+        std::unique_ptr<descriptor_notification::descriptor_op> op;
+
+        if (int64_t numbytes = ::recv(sd, _data.data(), _data.size(), 0); numbytes > 0)
+        {
+            so_far += numbytes;
+        }
+        else if (numbytes == 0 || errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            std::uint32_t flags = 0;
+
+            if (_op) { flags = co_await *_op; }
+            else
+            {
+                left_thread = true;
+                op          = co_await start_read_operation();
+
+                if (!op) { state_->last_error_ = 0; }
+                else
+                {
+                    _op = op.get();
+
+                    flags = op->flags();
+                }
+            }
+
+            /* No flags means something happened internally */
+            /* Like a cancel or deconstruction              */
+            if (flags)
+            {
+                if (int64_t numbytes = ::recv(sd, _data.data(), _data.size(), 0); numbytes >= 0)
+                {
+                    so_far += numbytes;
+                }
+                else
+                {
+                    state_->last_error_ = errno;
+                }
+            }
+        }
+        else
+        {
+            state_->last_error_ = errno;
+        }
+
+        if (rejoin && left_thread) { co_await yield(rejoin_thread); }
+
+        co_return so_far;
+    }
+
+    guaranteed_future<size_t>
+    tcp_stream::write(
+        std::span<const char>                   _data,
+        descriptor_notification::descriptor_op* _op) noexcept
+    {
+        if (_op && _op->op_type() == descriptor_notification::descriptor_op::type::kRead)
+            [[unlikely]]
+        {
+            state_->last_error_ = 0;
+            co_return 0;
+        }
+
+        bool     rejoin      = _op == nullptr;
+        bool     left_thread = false;
+        thread_t rejoin_thread{engine_->get_event_loop().current_id()};
+
+        const auto sd      = state_->socket_->file_descriptor();
+        size_t     written = 0;
+
+        std::unique_ptr<descriptor_notification::descriptor_op> op;
+        do
+        {
+
+            if (int64_t numbytes =
+                    ::send(sd, _data.data() + written, _data.size() - written, MSG_NOSIGNAL);
+                numbytes > 0)
+            {
+                written += numbytes;
+            }
+            else if (!numbytes || errno == EWOULDBLOCK || errno == EAGAIN)
+            {
+                std::uint32_t flags = 0;
+                if (_op) { flags = co_await *_op; }
+                else
+                {
+                    left_thread = true;
+                    op          = co_await start_write_operation();
+
+                    if (!op)
+                    {
+                        state_->last_error_ = 0;
+                        break;
+                    }
+
+                    flags = op->flags();
+                    _op   = op.get();
+                }
+
+                /* No flags means something happened internally */
+                /* Like a cancel or deconstruction              */
+                if (!flags) { break; }
+            }
+            else
+            {
+                state_->last_error_ = errno;
+            }
+
+        } while (written < _data.size());
+
+        if (rejoin && left_thread) { co_await yield(rejoin_thread); }
 
         co_return written;
     }
 
-    async_function<>
-    tcp_stream::write_and_forget(std::vector<char> _data) noexcept
+    guaranteed_future<std::unique_ptr<descriptor_notification::descriptor_op>>
+    tcp_stream::start_write_operation() noexcept
     {
-        co_await write(_data);
+        return state_->socket_->start_write_operation();
     }
 
-    simple_future<>
-    tcp_stream::wait_for_writes() noexcept
+    [[nodiscard]] guaranteed_future<std::unique_ptr<descriptor_notification::descriptor_op>>
+    tcp_stream::start_read_operation() noexcept
     {
-        /* When we resume, all writes initiated before us */
-        /* Will be completed... */
-        auto lock = co_await state_->mtx_;
+        return state_->socket_->start_read_operation();
     }
 
     async_function<>
@@ -305,21 +348,17 @@ namespace zab {
         engine*                           _engine,
         std::unique_ptr<internal_state>&& _state) noexcept
     {
-        std::unique_ptr<internal_state> state(std::move(_state));
-        co_await clean_up(_engine, state);
+        if (_state) { co_await clean_up(_engine, std::move(_state)); }
     }
 
     void
-    tcp_stream::cancel_read() noexcept
-    {
-
-        auto old_handle = state_->cancel_handle_.exchange(nullptr, std::memory_order_acquire);
-        if (old_handle) { unpause(*old_handle, order::now()); }
-    }
+    tcp_stream::cancel() noexcept
+    { }
 
     simple_future<>
-    tcp_stream::clean_up(engine* _engine, std::unique_ptr<internal_state>& _state) noexcept
+    tcp_stream::clean_up(engine* _engine, std::unique_ptr<internal_state>&& _state) noexcept
     {
+        /* RAII is important here in ordering */
         struct clean {
 
                 ~clean()
@@ -330,8 +369,7 @@ namespace zab {
 
                     if (::close(socket_) && errno != EBADF)
                     {
-                        std::cerr << "zab: A tcp stream socket failed to close. "
-                                  << "\n";
+                        std::cerr << "zab: A tcp stream socket failed to close.\n";
                     }
                 }
 
@@ -339,13 +377,11 @@ namespace zab {
 
         } cln{_state->socket_->file_descriptor()};
 
-        {
-            /* wait for all writes to flush... */
-            auto lock = co_await _state->mtx_;
-        }
+        std::unique_ptr<internal_state> state(std::move(_state));
+
+        state->socket_->cancel();
 
         thread_t rejoin_thread{_engine->get_event_loop().current_id()};
-
         if (::shutdown(cln.socket_, SHUT_WR) != -1)
         {
             /* now try and wait for the buffer to deplete... */
@@ -356,37 +392,40 @@ namespace zab {
 
                 if (!outstanding) { break; }
 
-                co_await zab::yield(_engine, {order::now()}, rejoin_thread);
+                co_await zab::yield(_engine, order::milli(10), rejoin_thread);
             }
 
-            char   buffer[256];
-            size_t amount_flush = 0;
+            std::vector<char> buffer(1028);
+            size_t            amount_flush = 0;
+
+            std::unique_ptr<descriptor_notification::descriptor_op> op;
             /* now try and wait for client acknowledgement */
             for (int i = 0; i < 5;)
             {
-                if (int64_t numbytes = ::recv(cln.socket_, buffer, sizeof(buffer), 0); !numbytes)
+                if (int64_t numbytes = ::recv(cln.socket_, buffer.data(), buffer.size(), 0);
+                    !numbytes)
                 {
                     break;
                 }
                 else if (errno == EAGAIN || errno == EWOULDBLOCK)
                 {
+                    if (!op) { op = co_await state->socket_->start_read_operation(); }
+                    else
+                    {
+                        co_await *op;
+                    }
                     ++i;
-                    //_state->socket_->set_timeout(100);
-
-                    co_await *_state->socket_;
                 }
                 else
                 {
                     amount_flush += numbytes;
                     /* If we flush more then 32 kb, then they are probably ignoring us */
                     if (amount_flush >= 1028 * 32) { break; }
-
-                    co_await zab::yield(_engine, {order::now()}, rejoin_thread);
                 }
             }
         }
 
-        _state->socket_ = std::nullopt;
+        state->socket_ = std::nullopt;
         /* now good to close! (RAII) */
     }
 

--- a/test/test-async_barrier.cpp
+++ b/test/test-async_barrier.cpp
@@ -108,8 +108,6 @@ namespace zab::test {
                     {
                         ++rounds;
 
-                        // //std::cout << "Done round: " << rounds << " out of " << threads_ *
-                        // kRounds << "\n";
                         if (rounds == threads_ * kRounds) { sem.release(); }
                     },
                     thread_t{0});
@@ -289,8 +287,6 @@ namespace zab::test {
                     {
                         ++rounds;
 
-                        // std::cout << "Done round: " << rounds << " out of " << threads_ * kRounds
-                        // << "\n";
                         if (rounds == threads_ * kRounds) { sem.release(); }
                     },
                     thread_t{0});
@@ -309,7 +305,6 @@ namespace zab::test {
                     co_await yield(now(), thread_t{t});
                 }
 
-                // std::cout << count.load() << " == " << compute_cycles() << "\n";
                 co_return count.load() == compute_cycles();
             }
 
@@ -333,7 +328,6 @@ namespace zab::test {
 
                 while (reducer)
                 {
-                    // std::cout <<  "DOING WORK " << reducer << "\n";
                     if (expected(get_engine()->get_event_loop().current_id(), thread_t{_id}))
                     {
                         get_engine()->stop();
@@ -341,8 +335,6 @@ namespace zab::test {
                     }
 
                     co_await _barrier.arrive_and_wait();
-
-                    // std::cout <<  "WAKIGN WORK"<< "\n";
 
                     if (expected(get_engine()->get_event_loop().current_id(), thread_t{_id}))
                     {
@@ -359,7 +351,6 @@ namespace zab::test {
                     ++internal_count;
                 }
 
-                // std::cout <<  "WORK IS OVER!"<< "\n";
                 if (_id != threads_ - 1) { _barrier.arrive_and_drop(); }
                 else
                 {
@@ -388,7 +379,6 @@ namespace zab::test {
             reusable_future<>
             do_sync_phase(async_binary_semaphore& sem)
             {
-                // std::cout <<  "SYN PHASE!"<< "\n";
                 size_t rounds = 0;
 
                 while (rounds != threads_ * kRounds)
@@ -401,8 +391,6 @@ namespace zab::test {
 
                     if (rounds != threads_ * kRounds) { co_yield promise_void{}; }
 
-                    // std::cout <<  "SYN PHASE AWAKE" << rounds << "\n";
-
                     if (expected(get_engine()->get_event_loop().current_id(), thread_t{0}))
                     {
                         get_engine()->stop();
@@ -410,7 +398,6 @@ namespace zab::test {
                     }
                 }
 
-                // std::cout <<  "SYN OVER"<< "\n";
                 sem.release();
 
                 co_return;
@@ -438,7 +425,6 @@ namespace zab::test {
                     co_await yield(now(), thread_t{t});
                 }
 
-                // std::cout << count.load() << " =1= " << compute_cycles() << "\n";
                 co_return count.load() == compute_cycles();
             }
 

--- a/test/test-async_semaphore.cpp
+++ b/test/test-async_semaphore.cpp
@@ -446,8 +446,6 @@ namespace zab::test {
             async_function<>
             acquire_count(async_latch& _latch) noexcept
             {
-                // std::cout << "Attempting" << "\n";
-
                 co_await *sem_;
 
                 ++count_;

--- a/test/test-first_of.cpp
+++ b/test/test-first_of.cpp
@@ -90,7 +90,7 @@ namespace zab::test {
 
                 if (duration >= order::in_seconds(2))
                 {
-                    std::cout << "Timer failed."
+                    std::cerr << "Timer failed."
                               << "\n";
                     engine_->stop();
                 }
@@ -193,7 +193,7 @@ namespace zab::test {
 
                 if (duration >= order::in_seconds(2))
                 {
-                    std::cout << "Timer failed."
+                    std::cerr << "Timer failed."
                               << "\n";
                     engine_->stop();
                 }

--- a/test/test-network_overlay.cpp
+++ b/test/test-network_overlay.cpp
@@ -90,7 +90,6 @@ namespace zab::test {
                 if (acceptor_.listen(AF_INET, 6998, 10))
                 {
                     auto stream_opt = co_await acceptor_.accept();
-
                     if (stream_opt)
                     {
                         auto amount = co_await stream_opt->write(
@@ -148,7 +147,6 @@ namespace zab::test {
                         {
                             if (!expected(strlen(kBuffer), buffer->size()))
                             {
-
                                 std::string_view og(kBuffer);
                                 buffer->emplace_back(0);
                                 std::string_view ng(buffer->data());
@@ -295,7 +293,7 @@ namespace zab::test {
             async_function<>
             run_stream(tcp_stream _stream)
             {
-                _stream.write_and_forget(std::vector<char>(kData));
+                co_await _stream.write(std::vector<char>(kData));
 
                 auto stream_opt = co_await _stream.read(kDataToSend);
 


### PR DESCRIPTION
Once either `start_*_operation()` or `co_await descriptor_op` returns, the user is put in the `descriptor_notifications` io thread. Essentially, users should complete their op or `co_await descriptor_op` again if they where unable to. `descriptor_op`'s are atomic whilst the user is within the io thread or is  `co_await`'ed on a `descriptor_op`. If the user leaves the io thread or does not  `co_await` on the `descriptor_op` on next suspend, atomicity is lost. For example, for your write operations to be atomic starting from `start_*_operation()` call, you should either try and write, or if busy, `co_await` the returned `descriptor_op`.